### PR TITLE
Correct typo in word 'browser' at en.yml locale

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,4 +2,4 @@ langcode: en-GB
 site_description: Piotr Macha — PHP Backend Developer
 inactive: inactive
 on_github: This site is open source on
-uses_cookies: This site uses cookies to hold information about your language and for making traffic statistics. If you would like to not have any cookies stored, please disable cookies in your borwser's settings, but keep in mind you won't be able to change the language.
+uses_cookies: This site uses cookies to hold information about your language and for making traffic statistics. If you would like to not have any cookies stored, please disable cookies in your browser's settings, but keep in mind you won't be able to change the language.


### PR DESCRIPTION
There is a typo in en.yml locales, where 'browser' is spelled 'borwser'. 